### PR TITLE
feat: use alpine base image, simplify Dockerfile, fix permission issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,69 +1,46 @@
-FROM php:7.2-fpm
+FROM php:7.2-fpm-alpine
 
-
-# Set working directory
 WORKDIR /var/www/html
 
 # Install dependencies
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    default-mysql-client \
-    libfreetype6-dev \
-    libpng-dev \
-    libjpeg62-turbo-dev \
-    locales \
+RUN apk update && apk add --no-cache \
+    build-base \
+    gcc \
+    mysql-client \
+    freetype libpng libjpeg-turbo freetype-dev libpng-dev libjpeg-turbo-dev \
+    icu-libs \
     jpegoptim optipng pngquant gifsicle \
     git \
-    curl \
-    nano \
-    zip \
-    unzip \
     npm \
-    wget \
     supervisor \
-    apache2
-
-
-# Clear cache
-RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+    apache2 \
+    apache2-ctl \
+    apache2-proxy
 
 # Installing extensions
 RUN docker-php-ext-install mysqli pdo_mysql mbstring exif pcntl pdo bcmath
 RUN docker-php-ext-configure gd --with-gd --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/
 RUN docker-php-ext-install gd
 
-
-
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-
-RUN groupadd -g 1000 www
-RUN useradd -u 1000 -ms /bin/bash -g www www
-
-
-RUN cd /var/www/html && \
-    wget https://github.com/Leantime/leantime/releases/download/v2.0.11/Leantime-V2.0.11.tar.gz && \
+RUN curl -LJO https://github.com/Leantime/leantime/releases/download/v2.0.11/Leantime-V2.0.11.tar.gz && \
     tar -zxvf Leantime-V2.0.11.tar.gz --strip-components 1
 
-
-RUN chmod 775 . && \
-    chgrp www-data . && \
-    chmod g+s .
-
+RUN chown www-data -R .
 
 COPY ./start.sh /start.sh
-
-RUN chown root:root /start.sh && \
-    chmod 4755 /start.sh
-
+RUN chmod +x /start.sh
 
 COPY config/custom.ini /usr/local/etc/php/conf.d/custom.ini
 
 # Configure supervisord
 COPY config/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-COPY config/app.conf /etc/apache2/sites-available/000-default.conf
+COPY config/app.conf  /etc/apache2/conf.d/app.conf
 
-RUN a2enmod proxy_fcgi rewrite
+RUN sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf && \
+    sed -i 's#AllowOverride [Nn]one#AllowOverride All#' /etc/apache2/httpd.conf && \
+    sed -i '$iLoadModule proxy_module modules/mod_proxy.so' /etc/apache2/httpd.conf
 
 # Expose port 9000 and start php-fpm server
 ENTRYPOINT ["/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN docker-php-ext-install gd
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-RUN curl -LJO https://github.com/Leantime/leantime/releases/download/v2.0.11/Leantime-V2.0.11.tar.gz && \
-    tar -zxvf Leantime-V2.0.11.tar.gz --strip-components 1
+RUN curl -LJO https://github.com/Leantime/leantime/releases/download/v2.0.12/Leantime-V2.0.12.tar.gz && \
+    tar -zxvf Leantime-V2.0.12.tar.gz --strip-components 1
 
 RUN chown www-data -R .
 

--- a/config/app.conf
+++ b/config/app.conf
@@ -1,4 +1,6 @@
 LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+ServerName 127.0.0.1
+
 <VirtualHost *:80>
   DocumentRoot "/var/www/html/public"
 

--- a/config/app.conf
+++ b/config/app.conf
@@ -1,5 +1,5 @@
 LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
-ServerName 127.0.0.1
+ServerName 0.0.0.0
 
 <VirtualHost *:80>
   DocumentRoot "/var/www/html/public"

--- a/config/supervisord.conf
+++ b/config/supervisord.conf
@@ -13,8 +13,8 @@ stderr_logfile_maxbytes=0
 autorestart=false
 startretries=0
 
-[program:apache2]
-command=apache2ctl -D "FOREGROUND"
+[program:httpd]
+command=httpd -D "FOREGROUND"
 numprocs=1
 autostart=true
 autorestart=true


### PR DESCRIPTION
This PR switches the base image of the Dockerfile to the PHP 7.2 Alpine image, which reduced image sizes by about 100mb, but also required migrating the apt-get commands to apk, and apache2ctl to httpd commands. Additionally, unneeded packages and steps were removed from the Dockerfile. 

This PR should also implicitly fix issues #4 and #3 according to my testing.

Extensive acceptance testing is required before merging. 