### PR TITLE
Utilize new environment variables in V2.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,10 @@ services:
      image: leantime/leantime:latest
      container_name: leantime
      environment:
-         DB_HOST: 'mysql_leantime'
-         MYSQL_USER: 'admin'
-         MYSQL_PASSWORD: '321.qwerty'
-         MYSQL_DATABASE: 'leantime'
+         LEAN_DB_HOST: 'mysql_leantime'
+         LEAN_DB_USER: 'admin'
+         LEAN_DB_PASSWORD: '321.qwerty'
+         LEAN_DB_DATABASE: 'leantime'
      ports:
        - "9000:9000"
        - "80:80"

--- a/start.sh
+++ b/start.sh
@@ -8,16 +8,15 @@ if [ -f "$CONFIG" ]; then
 else
     echo "Creating configuration file!"
     cd $APP_DIR
-    cp /var/www/html/config/configuration.sample.php /var/www/html/config/configuration.php
-    sed -i 's/$dbHost="localhost"/$dbHost="'"${DB_HOST}"'"/g' config/configuration.php && \
-    sed -i 's/$dbUser=""/$dbUser="'"${MYSQL_USER}"'"/g' config/configuration.php && \
-    sed -i 's/$dbPassword=""/$dbPassword="'"${MYSQL_PASSWORD}"'"/g' config/configuration.php && \
-    sed -i 's/$dbDatabase=""/$dbDatabase="'"${MYSQL_DATABASE}"'"/g' config/configuration.php
+    cp config/configuration.sample.php ${CONFIG}
 
-    #generating 32 character string for session password
-    SESSION_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1)
-    sed -i 's/$sessionpassword = "3evBlq9zdUEuzKvVJHWWx3QzsQhturBApxwcws2m"/$sessionpassword = "'"${SESSION_PASSWORD}"'"/g' config/configuration.php
+    if [ -z "$LEAN_SESSION_PASSWORD" ]; then
+        #generating 32 character string for session password
+        SESSION_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1)
+        sed -i 's/$sessionpassword = "3evBlq9zdUEuzKvVJHWWx3QzsQhturBApxwcws2m"/$sessionpassword = "'"${SESSION_PASSWORD}"'"/g' ${CONFIG}
+    fi
 
 fi
 
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+


### PR DESCRIPTION
Use the environment variables introduced in https://github.com/Leantime/leantime/pull/201 see #10 
 - removes `sed` to edit the config, no longer needed to inject the values into the config
 - ~~put the session pass into the appropriate env var.~~

Other unrelated questions:
 - Do you have  Slack or do you have something else?
 - Also, add a guide for contributions? Obviously people like this.