### PR TITLE
fix: add sessions volume to survice restarts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm-alpine
+FROM docker.io/library/php:7.2-fpm-alpine
 
 ARG LEAN_VERSION=2.1.6
 
@@ -38,6 +38,9 @@ COPY config/app.conf  /etc/apache2/conf.d/app.conf
 RUN sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf && \
     sed -i 's#AllowOverride [Nn]one#AllowOverride All#' /etc/apache2/httpd.conf && \
     sed -i '$iLoadModule proxy_module modules/mod_proxy.so' /etc/apache2/httpd.conf
+
+RUN mkdir -p "/sessions" && chown www-data:www-data /sessions && chmod 0777 /sessions
+VOLUME [ "/sessions" ]
 
 # Expose port 9000 and start php-fpm server
 ENTRYPOINT ["/start.sh"]

--- a/config/custom.ini
+++ b/config/custom.ini
@@ -1,2 +1,3 @@
 memory_limit = 1G
 max_execution_time = 60
+session.save_path = "/sessions/"


### PR DESCRIPTION
problem description:
We host leantime in kubernetes, which restarts our deployment multiple times a day and currently forces all uses to login again. A simple persistent session storage would already fix this issue for us.

changes:
- adds a mountable docker volume for php sessions
- uses explicit docker-hub images, which fixes buildah/podman builds for us