### PR TITLE
added volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM docker.io/library/php:7.2-fpm-alpine
 ARG LEAN_VERSION=2.1.7
 
 WORKDIR /var/www/html
+WORKDIR /app
 
 # Install dependencies
 RUN apk update && apk add --no-cache \
@@ -42,6 +43,9 @@ RUN sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf && \
 
 RUN mkdir -p "/sessions" && chown www-data:www-data /sessions && chmod 0777 /sessions
 VOLUME [ "/sessions" ]
+VOLUME [ "/var/www/html/config" ]
+VOLUME [ "/var/www/html/public/userfiles" ]
+VOLUME [ "/var/www/html/userfiles" ]
 
 # Expose port 9000 and start php-fpm server
 ENTRYPOINT ["/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM docker.io/library/php:7.2-fpm-alpine
 #Change version to trigger build
 ARG LEAN_VERSION=2.1.7
 
-WORKDIR /var/www/html
 WORKDIR /app
 
 # Install dependencies
@@ -44,7 +43,7 @@ RUN sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf && \
 RUN mkdir -p "/sessions" && chown www-data:www-data /sessions && chmod 0777 /sessions
 VOLUME [ "/sessions" ]
 VOLUME [ "/var/www/html/config" ]
-VOLUME [ "/var/www/html/public/userfiles" ]
+VOLUME [ "/var/www/html/public" ]
 VOLUME [ "/var/www/html/userfiles" ]
 
 # Expose port 9000 and start php-fpm server

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN curl -LJO https://github.com/Leantime/leantime/releases/download/v${LEAN_VER
     tar -zxvf Leantime-v${LEAN_VERSION}.tar.gz --strip-components 1 && \
     rm Leantime-v${LEAN_VERSION}.tar.gz
 
-RUN chown www-data -R .
+RUN cp -r ./* /var/www/html/
+RUN chown www-data -R /var/www/html
 
 COPY ./start.sh /start.sh
 RUN chmod +x /start.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.3'
 services:
    db:
      image: mysql:5.7
+     #raspberry pi/arm users can use this image
+     #image: beercan1989/arm-mysql:5.7
      container_name: mysql_leantime
      volumes:
        - db_data:/var/lib/mysql
@@ -26,7 +28,16 @@ services:
      ports:
        - "9000:9000"
        - "80:80"
+     volumes:
+       - lean_config:/var/www/html/config
+       - lean_pub_user:/var/www/html/public/userfiles
+       - lean_user:/var/www/html/userfiles
+       - lean_sessions:/sessions
      depends_on:
        - db
 volumes:
-    db_data: {}
+    db_data:
+    lean_sessions:
+    lean_config:
+    lean_pub_user:
+    lean_user:

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+SRC_DIR="/app"
 APP_DIR="/var/www/html"
 CONFIG="/var/www/html/config/configuration.php"
 
@@ -7,7 +8,9 @@ if [ -f "$CONFIG" ]; then
     echo "Config file already exists!"
 else
     echo "Creating configuration file!"
+    cp -r $SRC_DIR/* $APP_DIR/
     cd $APP_DIR
+    chown www-data -R .
     cp config/configuration.sample.php ${CONFIG}
 
     if [ -z "$LEAN_SESSION_PASSWORD" ]; then


### PR DESCRIPTION
Hi,

I changed `start.sh` and `Dockerfile` so that volumes can now be used. 

I added a temporary folder `/app` in which leantime is extracted initially. The files are then first copied to `/var/www/html` in `start.sh` because this way, if the volume is empty the configuration files will be created on startup.

The issue with extracting to `/var/www/html` in the Dockerfile-build is that if you mount a volume to that folder or any subfolders it overwrites the files that are already there.

I also added a comment to `docker-compose.yaml` informing rpi/arm users that they need to use a differen mysql image.

This closes [#35](https://github.com/Leantime/leantime/issues/775)

I hope I didn't miss any contribution rules.