### PR TITLE
MySQL 8.0 upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
    db:
-     image: mysql:5.7
+     image: mysql:8.0
      container_name: mysql_leantime
      volumes:
        - db_data:/var/lib/mysql


### PR DESCRIPTION
MySQL 5.7 has one year of support left; MySQL 8.0 has 4 years left.
MySQL 8.0 is already 4 years old, so has matured enough to be used by lots op projects.
As long as you use UTF-8 (or utf8mb4), MySQL 8.0 is as fast or up to 4 times as fast as its predecessor. (especially in high load situations)
Also, MySQL 8.0 is available for ARM devices; MySQL 5.7 not. (at least when talking about docker containers)