### PR TITLE
Opache and jit for php8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,11 @@ RUN apk update && apk add --no-cache \
     apache2-proxy
 
 # Installing extensions
-RUN docker-php-ext-install mysqli pdo_mysql mbstring exif pcntl pdo bcmath
+RUN docker-php-ext-install mysqli pdo_mysql mbstring exif pcntl pdo bcmath opcache
 RUN docker-php-ext-configure gd --enable-gd --with-jpeg=/usr/include/ --with-freetype --with-jpeg
 RUN docker-php-ext-install gd
 
+#Installing Leantime
 RUN curl -LJO https://github.com/Leantime/leantime/releases/download/v${LEAN_VERSION}/Leantime-v${LEAN_VERSION}.tar.gz && \
     tar -zxvf Leantime-v${LEAN_VERSION}.tar.gz --strip-components 1 && \
     rm Leantime-v${LEAN_VERSION}.tar.gz

--- a/config/custom.ini
+++ b/config/custom.ini
@@ -1,3 +1,4 @@
 memory_limit = 1G
 max_execution_time = 60
 session.save_path = "/sessions/"
+opcache.jit_buffer_size=128M


### PR DESCRIPTION
opcache and certainly JIT are 2 important aspects for php8 when it comes to performance.
After some testing on Leantime, the same server can handle ~30% more connections a second.

![image](https://user-images.githubusercontent.com/8971696/183382618-1d088774-c77e-4bcd-9f5f-ef2ca335d0b0.png)

