### PR TITLE
Fixed typo for depends_on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     ports:
       - "8080:80"
     depends_on:
-      - db
+      - leantime_db
 
 volumes:
   db_data: {}


### PR DESCRIPTION
depends_on on had the old container name as a value, changed to the new container new `leantime_db`