### PR TITLE
add restart always to the webservice

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
   leantime:
     image: leantime/leantime:latest
     container_name: leantime
+    restart: always
     environment:
       LEAN_APP_URL: 'https://leantime.domain.com' #Base URL, trailing slash not needed (Optional)
       LEAN_SITENAME: 'Leantime' #Name of your site, can be changed later


### PR DESCRIPTION
I often have only my db running. Went to check and saw that only the db has a restart setting. Added it to the webservice.