### PR TITLE
mysql:latest to mysql:8.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   leantime_db:
-    image: mysql:latest
+    image: mysql:8.0
     container_name: mysql_leantime
     volumes:
       - db_data:/var/lib/mysql


### PR DESCRIPTION
We need to specify the version we have tested Leantime against. Otherwise, we will encounter braking changes with newer MySQL versions.