### PR TITLE
Updated docker compose file and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,32 +14,31 @@ Leantime is an open source project management system for small teams and startup
 This is the official <a href="https://hub.docker.com/r/leantime/leantime">Docker image for Leantime</a>. It was built using the <a href="https://github.com/Leantime/leantime/releases">latest Leantime release</a>.
 
 ## How to use this image
+Bellow you will find examples on how to get started with Leantime trough `docker run` or `docker compose`.
 
-To run this image you will need an existing MySQL database. 
+### Full Set up with docker-compose
+
+One command install with docker compose.
 
 ```
-docker run -d --restart unless-stopped -p 80:80
--e LEAN_DB_HOST=mysql_leantime \
--e LEAN_DB_USER=admin \
--e LEAN_DB_PASSWORD=321.qwerty \
--e LEAN_DB_DATABASE=leantime \
---name leantime leantime/leantime:latest
+git clone https://github.com/Leantime/docker-leantime.git
+cd docker-leantime
+cp sample.env .env
+docker compose up -d
 ```
-You can set any of the config variables in `config/configuration.php` when running the docker command.
 
-Once started you can go to `<yourdomain.com>/install` and run the installation script.
+Dont forget to update the `.env` file for production.
 
-## Full set up with MySQL and network
+### Full set up with docker run
 
-If you don't have a MySQL database set up and would like to create a container follow these instruction.
-
-1. Create the network so Leantime can communicate with the MySql container.
+#### 1. Create the network so Leantime can communicate with the MySql container.
 
 ```
 docker network create leantime-net
 ```
 
-2. Create the MySQL container.
+#### 2. Create the MySQL container.
+If you don't have a MySQL database set up and would like to create a container follow these instruction, otherwise jump to step 3.
 
 ```
 docker run -d --restart unless-stopped -p 3306:3306 --network leantime-net \
@@ -47,10 +46,10 @@ docker run -d --restart unless-stopped -p 3306:3306 --network leantime-net \
 -e MYSQL_DATABASE=leantime \
 -e MYSQL_USER=admin \
 -e MYSQL_PASSWORD=321.qwerty \
---name mysql_leantime mysql:8.0 --character-set-server=utf8 --collation-server=utf8_unicode_ci
+--name mysql_leantime mysql:8.0 --character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci
 ```
 
-3. Create the Leantime container.
+#### 3. Create the Leantime container.
 
 ```
 docker run -d --restart unless-stopped -p 80:80 --network leantime-net \
@@ -62,16 +61,6 @@ docker run -d --restart unless-stopped -p 80:80 --network leantime-net \
 ```
 
 4. Run the installation script at `<yourdomain.com>/install`
-
-## Full Set up with docker-compose
-
-One command install with docker-compose.
-
-```
-git clone https://github.com/Leantime/docker-leantime.git
-cd docker-leantime
-docker-compose up -d
-```
 
 ## Docker secrets
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,36 +7,30 @@ services:
     volumes:
       - db_data:/var/lib/mysql
     restart: unless-stopped
-    environment:
-      MYSQL_ROOT_PASSWORD: '321.qwerty'
-      MYSQL_DATABASE: 'leantime'
-      MYSQL_USER: 'admin'
-      MYSQL_PASSWORD: '321.qwerty'
+    env_file: ./.env                                        # Environment file with settings
+    networks:
+      - leantime-net
     command: --character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci
 
   leantime:
     image: leantime/leantime:latest
     container_name: leantime
     restart: unless-stopped
-    environment:
-      # LEAN_APP_URL: 'https://domain.com/leantime'                     # Only needed for subdirectory setup; protocol (http or https) and base URL , trailing slash not needed
-      LEAN_SITENAME: 'Leantime'                                         # Name of your site, can be changed later
-      LEAN_DB_HOST: 'mysql_leantime'                                    # Database host, derived from container_name in leantime_db container
-      LEAN_DB_USER: 'admin'
-      LEAN_DB_PASSWORD: '321.qwerty'
-      LEAN_DB_DATABASE: 'leantime'
-      LEAN_DEFAULT_TIMEZONE: 'Europe/Stockholm'                         # Set default server timezone
-      LEAN_SESSION_PASSWORD: 'GD8Fozemg3AqM9my86TTfgTeGPXXkPF7'         # Salting sessions. Replace with a strong password
-      LEAN_SESSION_EXPIRATION: 28800                                    # How many seconds after inactivity should we logout?  28800seconds = 8hours
+    env_file: ./.env                                        # Environment file with settings
+    networks:
+      - leantime-net
     volumes:
-      - public_userfiles:/var/www/html/public/userfiles
-      - userfiles:/var/www/html/userfiles
+      - public_userfiles:/var/www/html/public/userfiles     # Volume to store public files, logo etc
+      - userfiles:/var/www/html/userfiles                   # Volume to store private user uploaded files
     ports:
-      - "8080:80"                                                       # The port to expose and access Leantime
+      - "8080:80"                                           # The port to expose and access Leantime
     depends_on:
-      - leantime_db                                                     # Don't start Leantime unless leantime_db is running
+      - leantime_db                                         # Don't start Leantime unless leantime_db is running
 
 volumes:
   db_data:
   userfiles:
   public_userfiles:
+
+networks:
+  leantime-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       MYSQL_DATABASE: 'leantime'
       MYSQL_USER: 'admin'
       MYSQL_PASSWORD: '321.qwerty'
-    command: --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    command: --character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci
 
   leantime:
     image: leantime/leantime:latest

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,163 @@
+# This is a sample configuration file with all possible configuration options.
+# If you don't want to maintain a file like this you can pass in all variables via Server Variabels
+
+## Minimum Configuration, these are required for installation
+
+LEAN_APP_URL = ''                                  # Base URL, only needed for subfolder installation
+LEAN_APP_URL_ROOT = ''                             # Base of application withotu trailing slash (used for cookies), e.g, /leantime
+
+LEAN_DEBUG = 0                                     # Debug flag
+
+# Database - MySQL container
+MYSQL_ROOT_PASSWORD: 'changeme123'                 # Database password
+MYSQL_DATABASE: 'leantime'                         # Database name
+MYSQL_USER: 'lean'                                 # Database username
+MYSQL_PASSWORD: 'changeme123'                      # Database password
+
+# Database - leantime container
+LEAN_DB_HOST = 'mysql_leantime'                    # Database host
+LEAN_DB_USER = 'lean'                              # Database username
+LEAN_DB_PASSWORD = 'changeme123'                   # Database password
+LEAN_DB_DATABASE = 'leantime'                      # Database name
+LEAN_DB_PORT = '3306'                              # Database port
+
+
+## Optional Configuraiton, you may ommit these from your .env file
+
+## Default Settings
+LEAN_SITENAME = 'Leantime'                         # Name of your site, can be changed later
+LEAN_LANGUAGE = 'en-US'                            # Default language
+LEAN_DEFAULT_TIMEZONE = 'America/Los_Angeles'      # Set default timezone
+LEAN_ENABLE_MENU_TYPE = false                      # Enable to specifiy menu on aproject by project basis
+LEAN_SESSION_PASSWORD = '3evBlq9zdUEuzKvVJHWWx3QzsQhturBApxwcws2m'  #Salting sessions. Replace with a strong password
+LEAN_SESSION_EXPIRATION = 28800                    # How many seconds after inactivity should we logout?  28800seconds = 8hours
+LEAN_LOG_PATH = null                                # Default Log Path (including filename), if not set /logs/error.log will be used
+
+## Look & Feel, these settings are available in the UI and can be overwritten there.
+LEAN_LOGO_PATH = '/images/logo.svg'                # Default logo path, can be changed later
+LEAN_PRINT_LOGO_URL = '/images/logo.jpg'           # Default logo URL use for printing (must be jpg or png format)
+LEAN_DEFAULT_THEME = 'default'                     # Default theme
+LEAN_PRIMARY_COLOR = '#1b75bb'                     # Primary Theme color
+LEAN_SECONDARY_COLOR = '#81B1A8'                   # Secondary Theme Color
+LEAN_KEEP_THEME = true                             # Keep theme and language from previous user for login screen
+
+## Fileuploads
+
+# Local File Uploads
+LEAN_USER_FILE_PATH = 'userfiles/'                 # Local relative path to store uploaded files (if not using S3)
+LEAN_DB_BACKUP_PATH = 'backupdb/'                  # Local relative path to store backup files, need permission to write
+
+# S3 File Uploads
+# LEAN_USE_S3 = false                                # Set to true if you want to use S3 instead of local files
+# LEAN_S3_KEY = ''                                   # S3 Key
+# LEAN_S3_SECRET = ''                                # S3 Secret
+# LEAN_S3_BUCKET = ''                                # Your S3 bucket
+# LEAN_S3_USE_PATH_STYLE_ENDPOINT = false            # Sets the endpoint style: false => https://[bucket].[endpoint] ; true => https://[endpoint]/[bucket]
+# LEAN_S3_REGION = ''                                # S3 region
+# LEAN_S3_FOLDER_NAME = ''                           # Foldername within S3 (can be emtpy)
+# LEAN_S3_END_POINT = null                           # S3 EndPoint S3 Compatible (https://sfo2.digitaloceanspaces.com)
+
+## Email
+LEAN_EMAIL_RETURN = ''                             # Return email address, needs to be valid email address format
+LEAN_EMAIL_USE_SMTP = false                        # Use SMTP? If set to false, the default php mail() function will be used
+LEAN_EMAIL_SMTP_HOSTS = ''                         # SMTP host
+LEAN_EMAIL_SMTP_AUTH = true                        # SMTP authentication required
+LEAN_EMAIL_SMTP_USERNAME = ''                      # SMTP username
+LEAN_EMAIL_SMTP_PASSWORD = ''                      # SMTP password
+LEAN_EMAIL_SMTP_AUTO_TLS = true                    # SMTP Enable TLS encryption automatically if a server supports it
+LEAN_EMAIL_SMTP_SECURE = ''                        # SMTP Security protocol (usually one of: TLS, SSL, STARTTLS)
+LEAN_EMAIL_SMTP_SSLNOVERIFY = false                # SMTP Allow insecure SSL: Don't verify certificate, accept self-signed, etc.
+LEAN_EMAIL_SMTP_PORT = ''                          # Port (usually one of 25, 465, 587, 2526)
+
+## Ldap
+# LEAN_LDAP_USE_LDAP = false                         # Set to true if you want to use LDAP
+# LEAN_LDAP_LDAP_TYPE = 'OL'                         # Select the correct directory type. Currently Supported: OL - OpenLdap, AD - Active Directory
+# LEAN_LDAP_HOST = ''                                # FQDN
+# LEAN_LDAP_PORT = 389                               # Default Port
+# LEAN_LDAP_DN = ''                                  # Location of users, example: CN=users,DC=example,DC=com
+
+                                                   # Leantime->Ldap attribute mapping
+# LEAN_LDAP_KEYS="{
+#         \"username\":\"uid\",
+#         \"groups\":\"memberOf\",
+#         \"email\":\"mail\",
+#         \"firstname\":\"displayname\",
+#         \"lastname\":\"\",
+#         \"phonenumber\":\"telephoneNumber\"
+# }"
+
+# For AD use these default attributes
+# LEAN_LDAP_KEYS="{
+#        \"username\":\"cn\",
+#        \"groups\":\"memberOf\",
+#        \"email\":\"mail\",
+#        \"firstname\":\"givenName\",
+#        \"lastname\":\"sn\",
+#        \"phonenumber\":\"telephoneNumber\"
+#      }"
+
+# LEAN_LDAP_DEFAULT_ROLE_KEY = 20;                   # Default Leantime Role on creation. (set to editor)
+
+# Default role assignments upon first login.
+# (Optional) Can be updated later in user settings for each user
+# LEAN_LDAP_GROUP_ASSIGNMENT="{
+#                \"5\": {
+#                  \"ltRole\":\"readonly\",
+#                  \"ldapRole\":\"readonly\"
+#                },
+#                \"10\": {
+#                  \"ltRole\":\"commenter\",
+#                   \"ldapRole\":\"commenter\"
+#                },
+#                \"20\": {
+#                  \"ltRole\":\"editor\",
+#                   \"ldapRole\":\"editor\"
+#                },
+#                \"30\": {
+#                  \"ltRole\":\"manager\",
+#                   \"ldapRole\":\"manager\"
+#                },
+#                \"40\": {
+#                  \"ltRole\":\"admin\",
+#                   \"ldapRole\":\"administrators\"
+#                },
+#                \"50\": {
+#                  \"ltRole\":\"owner\",
+#                  \"ldapRole\":\"administrators\"
+#                }
+# }"
+
+## OpenID Connect
+# required
+# LEAN_OIDC_ENABLE = false
+# LEAN_OIDC_CLIEND_ID =
+# LEAN_OIDC_CLIEND_SECRET =
+
+# required - the url for your provider (examples down below)
+#LEAN_OIDC_PROVIDER_URL =
+
+# optional - these will be read from the well-known configuration if possible
+#LEAN_OIDC_AUTH_URL_OVERRIDE =
+#LEAN_OIDC_TOKEN_URL_OVERRIDE =
+#LEAN_OIDC_JWKS_URL_OVERRIDE =
+#LEAN_OIDC_USERINFO_URL_OVERRIDE =
+
+# optional - override the public key for RSA validation
+#LEAN_OIDC_CERTIFICATE_STRING =
+#LEAN_OIDC_CERTIFICATE_FILE =
+
+# optional - override the requested scopes
+#LEAN_OIDC_SCOPES =
+
+# optional - override the keys used for these fields
+#LEAN_OIDC_FIELD_EMAIL =
+#LEAN_OIDC_FIELD_FIRSTNAME =
+#LEAN_OIDC_FIELD_LASTNAME =
+
+## OpenID Connect setting for github
+#LEAN_OIDC_PROVIDER_URL = https://token.actions.githubusercontent.com/
+#LEAN_OIDC_AUTH_URL_OVERRIDE = https://github.com/login/oauth/authorize
+#LEAN_OIDC_TOKEN_URL_OVERRIDE = https://github.com/login/oauth/access_token
+#LEAN_OIDC_USERINFO_URL_OVERRIDE = https://api.github.com/user,https://api.github.com/user/emails
+#LEAN_OIDC_SCOPES = user:email
+#LEAN_OIDC_FIELD_EMAIL = 0.email


### PR DESCRIPTION
# Updates
- Docker compose file update:
  - Environment variables moved to and replaced by env_file
  - Fixed warning from MySQL container
- README file was updated to reflect changes in the docker compose and to remove duplicate information regarding getting started with `docker run`.

## Moving environment variables to env_file
Current users of the docker compose file need to move their environment variables from the `docker-compose.yml` file to the `.env` file before doing `docker compose up -d`. 

This move of environment variables should give the user more flexibility and control regarding setting up and changing the configuration. The docker-compose.yml file will also be less cluttered, while the user gets all possible environment variables in the env_file.

## More info on "Fixed warning from MySQL container"
```sh
--character-set-server: 'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
--collation-server: 'utf8mb3_unicode_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
```
This was fixed by replacing
`command: --character-set-server=utf8--collation-server=utf8_unicode_ci`
with
`command: --character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci`
This will not affect current running instances.

## Testing of the changes
All changes have been tested on a new setup and on a current running setup.

- Test on new setup consist of following the updated instructions in the README file
- Test on current setup involved using the new docker-compose.yml file and moving any current environment variables to the env_file