### PR TITLE
Add LEAN_PORT to sample.env to match docker-compose.yml.

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -3,8 +3,8 @@
 
 ## Minimum Configuration, these are required for installation
 
-LEAN_PORT = 80
-LEAN_APP_URL = ''                                  # Base URL, only needed for subfolder installation
+LEAN_PORT = 80                                # The port to expose and access Leantime
+LEAN_APP_URL = ''                             # Base URL, only needed for subfolder installation
 LEAN_APP_DIR = ''                             # Base of application without trailing slash (used for cookies), e.g, /leantime
 
 LEAN_DEBUG = 0                                     # Debug flag

--- a/sample.env
+++ b/sample.env
@@ -3,6 +3,7 @@
 
 ## Minimum Configuration, these are required for installation
 
+LEAN_PORT = 80
 LEAN_APP_URL = ''                                  # Base URL, only needed for subfolder installation
 LEAN_APP_DIR = ''                             # Base of application without trailing slash (used for cookies), e.g, /leantime
 


### PR DESCRIPTION
`docker-compose.yml` [expects](https://github.com/Leantime/docker-leantime/blob/278f9dd2fb86df5e5fcfc0f65c45c46050223b70/docker-compose.yml#L28) `LEAN_PORT` to be defined in the environment, but it is missing from the `sample.env` file.