### PR TITLE
leantime Performance optimization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ WORKDIR /var/www/html
 
 VOLUME [ "/sessions" ]
 
+# Do not use the dns file in the image, but use the dns of the host, or use docker run --dns to specify 
+RUN echo -n > /etc/resolv.conf
+
 # Expose port 80 and start php-fpm server
 ENTRYPOINT ["/start.sh"]
 EXPOSE 80


### PR DESCRIPTION
Do not use the dns file in the image, but use the dns of the host, or use docker run --dns to specify  
Using the dns within the docker image will cause requests in the internal network environment to be very slow.