### PR TITLE
Mysql update 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker run -d --restart unless-stopped -p 3306:3306 --network leantime-net \
 -e MYSQL_DATABASE=leantime \
 -e MYSQL_USER=admin \
 -e MYSQL_PASSWORD=321.qwerty \
---name mysql_leantime mysql:8.0 --character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci
+--name mysql_leantime mysql:8.4 --character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci
 ```
 
 #### 3. Create the Leantime container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   leantime_db:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: mysql_leantime
     volumes:
       - db_data:/var/lib/mysql

--- a/sample.env
+++ b/sample.env
@@ -4,13 +4,13 @@
 ## Minimum Configuration, these are required for installation
 
 LEAN_PORT = '8081'                                 # The port to expose and access Leantime
-LEAN_APP_URL = ''                                  # Base URL, needed for subfolder or proxy installs
+LEAN_APP_URL = ''                                  # Base URL, needed for subfolder or proxy installs (including http:// or https://)
 LEAN_APP_DIR = ''                                  # Base of application without trailing slash (used for cookies), e.g, /leantime
 
 LEAN_DEBUG = 0                                     # Debug flag
 
 # Database - MySQL container
-MYSQL_ROOT_PASSWORD = 'changeme123'                # Database password
+MYSQL_ROOT_PASSWORD = 'changeme123'                # MySQL root password
 MYSQL_DATABASE = 'leantime'                        # Database name
 MYSQL_USER = 'lean'                                # Database username
 MYSQL_PASSWORD = 'changeme123'                     # Database password


### PR DESCRIPTION
Although the current MySQL 8.0 is still good for 8 months in updates, the next LTS has been out for almost half a year. 
New users should use the newer version database from the start to avoid a server update within the same year of installation.

With the MySQL 8.4 we are good until 2029-04-30 (4 years and 8 months from now).

MySQL 8.0 vs 8.4 are only configuration changes (like the flush method, the innodb_log_buffersize, etc...) and more then a hundred bugfixes.  Although this 'should' mean that an upgrade is easy, it is still better to avoid it altogether. 

(also corrected and added to 2 descriptions in our .env sample file)