### PR TITLE
Update to PHP 8.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/php:8.1-fpm-alpine
+FROM docker.io/library/php:8.3-fpm-alpine
 
 # Build with: `docker build . --tag leantime:devel`
 


### PR DESCRIPTION
An update to PHP 8.3
The current PHP 8.1 lost basic support 8 months ago and extended support will end by the end of 2025.
PHP 8.3 is good in basic updates up the end of 2025 and extended support up to the end of 2027.

The PHP community says PHP 8.3 should be mostly compatible with PHP 8.1 project - with only minor code adjustments.
On the first sight, it seems to be working correctly, but I would like some more testing on this by the community before this gets integrated...

I went though most of the screens and the obvious functions, but I encourage a complete testing before merging.