### PR TITLE
Fix missing signal propagation for graceful termination of container 

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -48,4 +48,4 @@ fi
 # Ensure supervisord can write its pid file
 mkdir -p /run
 
-/usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
Im using rootless `podman` - someone should test the changes with docker.

Due to a small error in the following line
https://github.com/Leantime/docker-leantime/blob/61f3eeff681d55ad19d29c69045aac4c2c6a8b86/start.sh#L51
 incoming signals like SIGQUIT arent propagated which results in a SIGKILL:

> leantime[9017]: time="2026-01-22T11:16:40+01:00" level=warning msg="StopSignal SIGQUIT failed to stop container leantime in 10 seconds, resorting to SIGKILL"


`ps` shows the instance of `start.sh` still running after calling `supervisord`

```shell
$ podman exec -it leantime ps -eo pid,ppid,stat,comm,args
PID   PPID  STAT COMMAND          COMMAND
    1     0 S    podman-init      /run/podman-init -- /sbin/tini -- /start.sh
    2     1 S    tini             /sbin/tini -- /start.sh
>>> 3     2 S    start.sh         {start.sh} /bin/sh /start.sh
    5     3 S    supervisord      {supervisord} /usr/bin/python3 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
    6     5 S    php-fpm          php-fpm: master process (/usr/local/etc/php-fpm.conf)
    7     5 S    nginx            nginx: master process nginx -g daemon off;
    8     5 S    php              php /var/www/html/bin/leantime schedule:work
    9     7 S    nginx            nginx: worker process
   10     7 S    nginx            nginx: worker process
   11     7 S    nginx            nginx: worker process
   12     7 S    nginx            nginx: worker process
   13     7 S    nginx            nginx: worker process
   14     7 S    nginx            nginx: worker process
   15     7 S    nginx            nginx: worker process
   16     7 S    nginx            nginx: worker process
   17     6 S    php-fpm          php-fpm: pool www
   18     6 S    php-fpm          php-fpm: pool www
   19     6 S    php-fpm          php-fpm: pool www
   20     6 S    php-fpm          php-fpm: pool www
   21     6 S    php-fpm          php-fpm: pool www
   24     0 R    ps               ps -eo pid,ppid,stat,comm,args
```

By putting `exec` infront of the call to `supervisord` fixes the signal propagation:
```shell
$ podman exec -it leantime ps -eo pid,ppid,stat,comm,args
PID   PPID  STAT COMMAND          COMMAND
    1     0 S    tini             /sbin/tini -- /start.sh
    2     1 S    supervisord      {supervisord} /usr/bin/python3 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
    4     2 S    php-fpm          php-fpm: master process (/usr/local/etc/php-fpm.conf)
    5     2 S    nginx            nginx: master process nginx -g daemon off;
    6     2 S    php              php /var/www/html/bin/leantime schedule:work
    7     5 S    nginx            nginx: worker process
    8     5 S    nginx            nginx: worker process
    9     5 S    nginx            nginx: worker process
   10     5 S    nginx            nginx: worker process
   11     5 S    nginx            nginx: worker process
   12     5 S    nginx            nginx: worker process
   13     5 S    nginx            nginx: worker process
   14     5 S    nginx            nginx: worker process
   15     4 S    php-fpm          php-fpm: pool www
   16     4 S    php-fpm          php-fpm: pool www
   17     4 S    php-fpm          php-fpm: pool www
   18     4 S    php-fpm          php-fpm: pool www
   19     4 S    php-fpm          php-fpm: pool www
   22     0 R    ps               ps -eo pid,ppid,stat,comm,args
```

Which shows in the logs as:

> systemd[778]: Stopping leantime.service...
> leantime[10045]: 2026-01-22 10:18:26,762 WARN received SIGQUIT indicating exit request
> leantime[10045]: 2026-01-22 10:18:26,762 WARN received SIGQUIT indicating exit request
> leantime[10045]: 2026-01-22 10:18:26,763 INFO waiting for php-fpm, nginx, scheduler to die
> leantime[10045]: 2026-01-22 10:18:26,763 INFO waiting for php-fpm, nginx, scheduler to die
> leantime[10045]: 2026-01-22 10:18:26,764 WARN stopped: scheduler (terminated by SIGTERM)
> leantime[10045]: 2026-01-22 10:18:26,764 WARN stopped: scheduler (terminated by SIGTERM)
> leantime[10045]: 2026-01-22 10:18:26,872 INFO stopped: nginx (exit status 0)
> leantime[10045]: 2026-01-22 10:18:26,872 INFO stopped: nginx (exit status 0)
> leantime[10045]: [22-Jan-2026 10:18:26] NOTICE: Terminating ...
> leantime[10045]: [22-Jan-2026 10:18:26] NOTICE: exiting, bye-bye!
> leantime[10045]: 2026-01-22 10:18:26,877 INFO stopped: php-fpm (exit status 0)
> leantime[10045]: 2026-01-22 10:18:26,877 INFO stopped: php-fpm (exit status 0)
> leantime[10190]: d3162bcf7953dc287e7b66b65e1228d651f066fe43c885a4e66f43499e3ab626
> systemd[778]: Stopped leantime.service.
> systemd[778]: leantime.service: Consumed 665ms CPU time, 96.6M memory peak.